### PR TITLE
Include .NET reference assemblies when using MonoGame

### DIFF
--- a/src/SpriteFontPlus.MonoGame.csproj
+++ b/src/SpriteFontPlus.MonoGame.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.Portable" PrivateAssets="All" Version="3.6.0.1625" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
SpriteFontPlus fails to compile on macOS when using MonoGame and targeting .NET Core. This is because the [`MonoGame.Framework.Portable`](https://www.nuget.org/packages/MonoGame.Framework.Portable) package it uses targets regular .NET. This pull request fixes that by adding the [`Microsoft.NETFramework.ReferenceAssemblies`](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies) package, which contains the, well, reference assemblies that `MonoGame.Framework.Portable` needs in order to work.